### PR TITLE
Bump build number to 1 to get updated zstd run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
   # these are no longer supported.
   skip: true   # [py<37 or win32]
-  number: 0
+  number: 1
   entry_points:
     - imagecodecs=imagecodecs.__main__:main
   ignore_run_exports:
@@ -25,10 +25,6 @@ build:
 
 requirements:
   build:
-    # - python                                 # [build_platform != target_platform]
-    # - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    # - cython                                 # [build_platform != target_platform]
-    # - numpy                                  # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - pkg-config  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ build:
     - libwebp  # [win or (osx and arm64)]
     - jpeg     # [win]
     - jxrlib   # [win]
+    - libbrotlicommon
 
 requirements:
   build:


### PR DESCRIPTION
Need to rebuild `imagecodecs-2021.8.26` so that it has the updated `zstd` `run_exports`. This should resolve the problem described [here](https://anaconda.atlassian.net/browse/PKG-333?focusedCommentId=135843)